### PR TITLE
dev: Update npm packages and update composer lockfile

### DIFF
--- a/kbuild
+++ b/kbuild
@@ -11,6 +11,7 @@ _npm () {
     if [ "$1" == 'dev' ];
     then
       npm install
+      npm update
     elif [ "$1" == 'release' ];
     then
       npm install
@@ -51,7 +52,11 @@ _composer () {
   then
     if [ "$1" == 'dev' ];
     then
-      composer install --ignore-platform-reqs || composer update --ignore-platform-reqs
+      if [ -f composer.lock ] && [ $(grep composer\\.lock .gitignore) ]
+      then
+        composer update --ignore-platform-reqs
+      fi
+      composer install --ignore-platform-reqs
     elif [ "$1" == 'release' ];
     then
       composer install -n --no-dev -o --prefer-dist --ignore-platform-reqs || composer update -n --prefer-dist --no-dev -o --ignore-platform-reqs 


### PR DESCRIPTION
- npm doesn't update packages with the install command. `npm update` added to fix this, but there might be a smarter way to do this (ie. don't always go bleeding-edge) using npm packages such as npm-check.  
- When we're not managing the composer.lock file in the git repo even though composer manual strongly recommend it (it was not managed properly), we have to run `composer update` or `rm composer.lock` to have a successful `composer install`, since the repo doesn't provide an updated lockfile. 
