### PR TITLE
fix: bower install crashing script before update resolves conflicts

### DIFF
--- a/kbuild/kbuild
+++ b/kbuild/kbuild
@@ -31,11 +31,9 @@ _bower () {
     if [ "$1" == 'dev' ];
     then
       bower --config.interactive=false prune
-      bower --config.interactive=false install
       bower --config.interactive=false update
     elif [ "$1" == 'release' ];
     then
-      bower --config.interactive=false install
       bower --config.interactive=false update
     fi
   fi


### PR DESCRIPTION
DEV mode: When bower.json manifest is updated, bower install will cause dependency version conflicts between manifest and previously installed versions and will exit with a non-zero status, causing kbuild to stop. If `set -e` or `bower install` is removed, bower update will still install new packages and update dependencies properly.

RELEASE mode: bower install follows exact manifest versions while ignoring semver, while bower update follows the latest semver declared in the bower.json file. Since we're starting on a clean directory, bower install downloads old versions and bower update updates the versions. bower update on an empty directory simply installs new versions without downloading everything twice. 
